### PR TITLE
Remove extensions on update

### DIFF
--- a/BackEnd/src/main/java/com/osta/marketplace/shedule/ExtensionsSynchronizerSchedule.java
+++ b/BackEnd/src/main/java/com/osta/marketplace/shedule/ExtensionsSynchronizerSchedule.java
@@ -81,6 +81,10 @@ public class ExtensionsSynchronizerSchedule {
     }
 
     private void updateDatabase(ExtensionDto[] extensions) {
+        if(extensions.length > 0) {
+            this.extensionRepository.deleteAll();
+        }
+
         for (var dto : extensions) {
             Extension extension = createExtensionEntity(dto);
             this.extensionRepository.save(extension);


### PR DESCRIPTION
### 🛠 Changes being made
When the new extensions json file is not empty, remove old database entries first so that no entries get duplicated.

### ✨ What's the context?
After a extensions.json update some extensions would get duplicated or old versions would be left in the back-end that where not present in the JSON file.

### 🧠 Rationale behind the change
We could also only remove database entries that did not change, but there would be a lot of overhead involved in doing this.

### 🧪 Testing
All tests still succeed.

### 📸 Screenshots (optional)
No UI changes

### 🏎 Quality check
- [X] Are there any errors, console logs, debuggers or leftover code in your changes?
- [X] Did you update the documentation for your code?