### PR TITLE
Show language on details page of an extension

### DIFF
--- a/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
+++ b/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
@@ -30,6 +30,7 @@ export function ExtensionDetailScreen() {
       <h2>Extension: {extensionDetails.name}</h2>
       <p>Area: {extensionDetails.area}</p>
       <p>Type: {extensionDetails.type}</p>
+      <p>Language: {extensionDetails.languages}</p>
       <p>{extensionDetails.description}</p>
       {Object.entries(extensionDetails.properties ?? {}).length > 0 && (
         <>

--- a/FrontEnd/src/types.d.ts
+++ b/FrontEnd/src/types.d.ts
@@ -22,6 +22,7 @@ export type MarketplaceExtension = {
  * @property {string} description - Description of the extension.
  * @property {string} area - Area where the extension is available.
  * @property {string} type - Type of the extension.
+ * @property {string} languages - Language of the extension.
  * @property {Record<string, string>} properties - Additional properties of the extension.
  * @property {Version[]} versions - List of available versions.
  */

--- a/FrontEnd/src/types.d.ts
+++ b/FrontEnd/src/types.d.ts
@@ -30,6 +30,7 @@ export type MarketPlaceExtensionDetails = {
   description: string
   area: string
   type: string
+  languages: string
   properties: Record<string, string>
   versions: Version[]
 }


### PR DESCRIPTION
### 🛠 Changes being made
- Add "languages" type of to MarketPlaceExtensionDetails
- Show language on details page

### ✨ What's the context?
Language was never shown.

### 🧠 Rationale behind the change
Now people can chose which extension they want based on the language.

### 🧪 Testing
No functional changes.

### 🏎 Quality check

- [x] Are there any errors, console logs, debuggers or leftover code in your changes?

- [x] Did you update the documentation for your code?
